### PR TITLE
Fixes absolutizing of wwwIndexHtml

### DIFF
--- a/src/compiler/config/test/validate-paths.spec.ts
+++ b/src/compiler/config/test/validate-paths.spec.ts
@@ -31,6 +31,14 @@ describe('validatePaths', () => {
     expect(path.isAbsolute(config.wwwIndexHtml)).toBe(true);
   });
 
+  it('should convert a custom wwwIndexHtml to absolute path', () => {
+    config.wwwIndexHtml = 'assets/custom-index.html';
+    validateBuildConfig(config);
+    expect(path.basename(config.wwwIndexHtml)).toBe('custom-index.html');
+    expect(path.isAbsolute(config.wwwIndexHtml)).toBe(true);
+  });
+
+
   it('should set default indexHtmlSrc and convert to absolute path', () => {
     validateBuildConfig(config);
     expect(path.basename(config.srcIndexHtml)).toBe('index.html');

--- a/src/compiler/config/validate-paths.ts
+++ b/src/compiler/config/validate-paths.ts
@@ -86,7 +86,7 @@ export function validatePaths(config: Config) {
     config.wwwIndexHtml = normalizePath(path.join(config.wwwDir, DEFAULT_INDEX_HTML));
   }
   if (!path.isAbsolute(config.wwwIndexHtml)) {
-    config.wwwIndexHtml = normalizePath(path.join(config.rootDir, config.wwwDir));
+    config.wwwIndexHtml = normalizePath(path.join(config.wwwDir, config.wwwIndexHtml));
   }
 
   if (typeof config.publicPath !== 'string') {


### PR DESCRIPTION
If wwwIndexHtml is not absolute, it is changed to wwwDir, which seems
like a copy-paste oversight.

This commit changes it to use the value of wwwIndexHtml relative to
wwwDir.

Fix for https://github.com/ionic-team/stencil/issues/469